### PR TITLE
Allow for toggling away on one/all connected clients (replaces #19)

### DIFF
--- a/clientaway.cpp
+++ b/clientaway.cpp
@@ -88,13 +88,13 @@ public:
 		// Valid value of true or false for setting away/unaway
 		bool sToggleFlag = true;
 		CString sToggleValue = "away";
+        VCString sReturn;
 
-		if (sLine.Split(" ",,false)).Equals(2) {
-			sToggleFlag = sLine.Token(2).ToBool();
-			if (!sToggleFlag) {
-				sToggleValue = "unaway";
-			}
-		}
+        // If the hostname argument isn't passed and only arg is true/false, treat that as sToggleFlag
+		if (sHostname.AsLower() == "true" || sHostname.AsLower() == "false" ) {
+			sToggleFlag = sHostname.ToBool();
+            sHostname = "";
+        }
 
 		unsigned int count = 0;
 
@@ -103,12 +103,21 @@ public:
 
 			//Set all hosts to away if we encounter an empty hostname
 			//Otherwise, set the flag to the provided second argument value
+            if (pClient->GetRemoteIP().Equals(sHostname)) {
+                if (sLine.Token(2).empty()) {
+                    sToggleFlag = !pClient->IsAway();
+                } else {
+                    sToggleFlag = sLine.Token(2).ToBool();
+                }
+            }
 			if (sHostname.empty() || pClient->GetRemoteIP().Equals(sHostname)) {
-//				pClient->SetAway(true);
 				pClient->SetAway(sToggleFlag);
 				++count;
-			}
+            }
 		}
+        if (!sToggleFlag) {
+            sToggleValue = "unaway";
+        }
 
 		if (count == 1) {
 			PutModule(CString(count) + " client has been set " + sToggleValue);

--- a/clientaway.cpp
+++ b/clientaway.cpp
@@ -89,7 +89,7 @@ public:
 		bool sToggleFlag = true;
 		CString sToggleValue = "away";
 
-		if (sLine.Split(" ",null,false)) == 2 {
+		if (sLine.Split(" ",,false)).Equals(2) {
 			sToggleFlag = sLine.Token(2).ToBool();
 			if (!sToggleFlag) {
 				sToggleValue = "unaway";
@@ -105,7 +105,7 @@ public:
 			//Otherwise, set the flag to the provided second argument value
 			if (sHostname.empty() || pClient->GetRemoteIP().Equals(sHostname)) {
 //				pClient->SetAway(true);
-				pClient=>SetAway(sToggleFlag);
+				pClient->SetAway(sToggleFlag);
 				++count;
 			}
 		}

--- a/clientaway.cpp
+++ b/clientaway.cpp
@@ -88,13 +88,13 @@ public:
 		// Valid value of true or false for setting away/unaway
 		bool sToggleFlag = true;
 		CString sToggleValue = "away";
-        VCString sReturn;
+		VCString sReturn;
 
-        // If the hostname argument isn't passed and only arg is true/false, treat that as sToggleFlag
+		// If the hostname argument isn't passed and only arg is true/false, treat that as sToggleFlag
 		if (sHostname.AsLower() == "true" || sHostname.AsLower() == "false" ) {
 			sToggleFlag = sHostname.ToBool();
-            sHostname = "";
-        }
+			sHostname = "";
+		}
 
 		unsigned int count = 0;
 
@@ -103,21 +103,21 @@ public:
 
 			//Set all hosts to away if we encounter an empty hostname
 			//Otherwise, set the flag to the provided second argument value
-            if (pClient->GetRemoteIP().Equals(sHostname)) {
-                if (sLine.Token(2).empty()) {
-                    sToggleFlag = !pClient->IsAway();
-                } else {
-                    sToggleFlag = sLine.Token(2).ToBool();
-                }
-            }
+			if (pClient->GetRemoteIP().Equals(sHostname)) {
+				if (sLine.Token(2).empty()) {
+					sToggleFlag = !pClient->IsAway();
+				} else {
+					sToggleFlag = sLine.Token(2).ToBool();
+				}
+			}
 			if (sHostname.empty() || pClient->GetRemoteIP().Equals(sHostname)) {
 				pClient->SetAway(sToggleFlag);
 				++count;
-            }
+			}
 		}
-        if (!sToggleFlag) {
-            sToggleValue = "unaway";
-        }
+		if (!sToggleFlag) {
+			sToggleValue = "unaway";
+		}
 
 		if (count == 1) {
 			PutModule(CString(count) + " client has been set " + sToggleValue);
@@ -175,13 +175,13 @@ public:
 						}
 					}
 
-#if (VERSION_MAJOR >= 1) && (VERSION_MINOR >= 5)
-					for (CQuery* pQuery : m_pNetwork->GetQueries()) {
-						m_pNetwork->DelQuery(pQuery->GetName());
-					}
-#else
-					m_pNetwork->ClearQueryBuffer();
-#endif
+					#if (VERSION_MAJOR >= 1) && (VERSION_MINOR >= 5)
+						for (CQuery* pQuery : m_pNetwork->GetQueries()) {
+							m_pNetwork->DelQuery(pQuery->GetName());
+						}
+					#else
+						m_pNetwork->ClearQueryBuffer();
+					#endif
 
 					if (GetAutoAway() && m_pNetwork->IsIRCAway()) {
 						PutIRC("AWAY");

--- a/clientaway.cpp
+++ b/clientaway.cpp
@@ -84,21 +84,36 @@ public:
 		const vector<CClient*> vClients = m_pUser->GetAllClients();
 
 		CString sHostname = sLine.Token(1);
+
+		// Valid value of true or false for setting away/unaway
+		bool sToggleFlag = true;
+		CString sToggleValue = "away";
+
+		if (sLine.Split(" ",null,false)) == 2 {
+			sToggleFlag = sLine.Token(2).ToBool();
+			if (!sToggleFlag) {
+				sToggleValue = "unaway";
+			}
+		}
+
 		unsigned int count = 0;
 
 		for (vector<CClient*>::const_iterator it = vClients.begin(); it != vClients.end(); ++it) {
 			CClient *pClient = *it;
 
+			//Set all hosts to away if we encounter an empty hostname
+			//Otherwise, set the flag to the provided second argument value
 			if (sHostname.empty() || pClient->GetRemoteIP().Equals(sHostname)) {
-				pClient->SetAway(true);
+//				pClient->SetAway(true);
+				pClient=>SetAway(sToggleFlag);
 				++count;
 			}
 		}
 
 		if (count == 1) {
-			PutModule(CString(count) + " client has been set away");
+			PutModule(CString(count) + " client has been set " + sToggleValue);
 		} else {
-			PutModule(CString(count) + " clients have been set away");
+			PutModule(CString(count) + " clients have been set " + sToggleValue);
 		}
 	}
 
@@ -209,4 +224,3 @@ template<> void TModInfo<CClientAwayMod>(CModInfo& Info) {
 }
 
 USERMODULEDEFS(CClientAwayMod, "This module allows you to set clients away independently, and auto away")
-


### PR DESCRIPTION
This replaces #19 by @badloop (while preserving his commits) and just adds implements @kylef's last comment about replacing the spaces with tabs.

I just stumbled upon this repo while search for the default away reason (which I unwillingly replaced with `""` 😇) and while I'm not a C++ programmer… converting spaces to tabs, that I can :).

Cheers!
:octocat: 
