### PR TITLE
Revert "clientaway: fix build with znc > 1.4 (fixes #17)"

### DIFF
--- a/clientaway.cpp
+++ b/clientaway.cpp
@@ -10,9 +10,7 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 #include <znc/Chan.h>
-#if (VERSION_MAJOR >= 1) && (VERSION_MINOR >= 5)
-#include <znc/Query.h>
-#endif
+
 using std::vector;
 
 #define AWAY_DEFAULT_REASON "Auto away at %time%"
@@ -151,13 +149,7 @@ public:
 						}
 					}
 
-#if (VERSION_MAJOR >= 1) && (VERSION_MINOR >= 5)
-					for (CQuery* pQuery : m_pNetwork->GetQueries()) {
-						m_pNetwork->DelQuery(pQuery->GetName());
-					}
-#else
 					m_pNetwork->ClearQueryBuffer();
-#endif
 
 					if (GetAutoAway() && m_pNetwork->IsIRCAway()) {
 						PutIRC("AWAY");


### PR DESCRIPTION
Reverts kylef/znc-contrib#18

ClearQueryBuffer was restored: https://github.com/znc/znc/pull/904